### PR TITLE
disable systemd crash dumps

### DIFF
--- a/toolbox.sh
+++ b/toolbox.sh
@@ -14,6 +14,7 @@ fi
 
 rm -rf /tmp/dumps
 mkdir -p --mode=000 /tmp/dumps
+sysctl kernel.core_pattern=core
 
 function unload {
     echo "Unloading cheat..."


### PR DESCRIPTION
sometimes when the game crashes, or you exit the game without unloading cheat, your system may froze for a few minutes creating a crash dump.
this is noticeable if you have low end CPU or HDD.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please consider not. -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of features to the cheat at the end of README.md in the root of this repository, please add your changes there if appropriate -->

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## Source / References:
<!--- Please include any forum posts/GitHub links relevant to the PR -->
